### PR TITLE
[Fix] 전략 상세 이슈 수정, 다른 페이지 이슈도 포함

### DIFF
--- a/src/api/strategyDetail.ts
+++ b/src/api/strategyDetail.ts
@@ -108,8 +108,10 @@ export const fetchPostDailyAnalysis = async (
     );
     return req.data;
   } catch (error) {
-    console.error('failed to fetch Post DailyAnalysis', error);
-    throw error;
+    const axiosError = error as AxiosError<{ message: string }>;
+    const errorMsg =
+      axiosError.response?.data?.message || '등록에 실패했습니다. 다시 시도해주세요.';
+    throw new Error(errorMsg);
   }
 };
 
@@ -133,8 +135,10 @@ export const fetchPutDailyAnalysis = async (
     );
     return req.data;
   } catch (error) {
-    console.error('failed to fetch Put DailyAnalysis', error);
-    throw error;
+    const axiosError = error as AxiosError<{ message: string }>;
+    const errorMsg =
+      axiosError.response?.data?.message || '수정에 실패했습니다. 다시 시도해주세요.';
+    throw new Error(errorMsg);
   }
 };
 
@@ -157,7 +161,10 @@ export const fetchDeleteDailyAnalysis = async (
     );
     return req.data;
   } catch (error) {
-    console.error('failed to Delete DailyAnalysis', error);
+    const axiosError = error as AxiosError<{ message: string }>;
+    const errorMsg =
+      axiosError.response?.data?.message || '삭제에 실패했습니다. 다시 시도해주세요.';
+    throw new Error(errorMsg);
   }
 };
 

--- a/src/components/common/LoadingSpin.tsx
+++ b/src/components/common/LoadingSpin.tsx
@@ -1,0 +1,26 @@
+import { css, keyframes } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+const spinAnimation = keyframes`
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+`;
+
+const loaderStyle = css`
+  display: inline-block;
+  width: 50px;
+  height: 50px;
+  border: 5px solid rgba(0, 0, 0, 0.1);
+  border-top: 5px solid ${theme.colors.main.primary};
+  border-radius: 50%;
+  animation: ${spinAnimation} 1s linear infinite;
+`;
+
+const LoadingSpin: React.FC = () => <div css={loaderStyle} />;
+
+export default LoadingSpin;

--- a/src/components/common/StrategyChart.tsx
+++ b/src/components/common/StrategyChart.tsx
@@ -46,7 +46,7 @@ const StrategyChart = ({ lineData, areaData }: LineChartProps) => {
     yAxis: [
       {
         labels: {
-          style: { color: colors.primary.fillColor },
+          style: { color: theme.colors.gray[800] },
           format: `{value:,.0f}`,
         },
         title: {
@@ -57,7 +57,7 @@ const StrategyChart = ({ lineData, areaData }: LineChartProps) => {
       },
       {
         labels: {
-          style: { color: colors.primary.lineColor },
+          style: { color: theme.colors.gray[800] },
         },
         title: {
           enabled: false,

--- a/src/components/navigation/TraderProfilePageNav.tsx
+++ b/src/components/navigation/TraderProfilePageNav.tsx
@@ -14,10 +14,7 @@ const TraderProfileNav = () => {
   const { traderId } = useParams();
   const { data: profileImageData } = useProfileImage(traderId || ''); // 프로필 이미지 가져오기
   const imageSrc = profileImageData?.fileUrl;
-  const { data: profileData } = useSidebarProfileQuery();
-  const [userImage] = useState(
-    'https://i.pinimg.com/736x/2b/4c/91/2b4c913711c4a8be893aa873b3b23193.jpg'
-  );
+  const { data: profileData } = useSidebarProfileQuery(traderId);
 
   const TraderMyPageNavItems = [
     {
@@ -26,20 +23,14 @@ const TraderProfileNav = () => {
     },
   ];
 
-  const desc = `📌 월급쟁이 직장인이 자산가로 💸
-  🏡 부동산 실전 투자 (2018~)
-  👣 파워 “J” 대기업 연구원의 
-  재테크 이야기
-  🇺🇸 미국주식 스터디 운영 / 링크👇🏻 www.modu.Chwieob.fighting.com`;
-
   return (
     <div css={navContainerStyle}>
       <div css={navWrapper}>
         <ProfileSection
-          userImage={imageSrc ?? userImage}
-          userRole='트레이더'
-          nickname='투자여왕'
-          desc={profileData?.data.introduction ?? desc}
+          userImage={imageSrc}
+          userRole={profileData?.data.memberType === 'TRADER' ? '트레이더' : '투자자'}
+          nickname={profileData?.data.nickname || ''}
+          desc={profileData?.data.introduction || ''}
         />
         <NavigationMenu items={TraderMyPageNavItems} />
       </div>

--- a/src/components/navigation/TraderProfilePageNav.tsx
+++ b/src/components/navigation/TraderProfilePageNav.tsx
@@ -1,5 +1,3 @@
-import { useState } from 'react';
-
 import { css } from '@emotion/react';
 import { useParams } from 'react-router-dom';
 

--- a/src/components/page/mypage-investor/myfolder/FollowModal.tsx
+++ b/src/components/page/mypage-investor/myfolder/FollowModal.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 
-import Loader from '@/components/common/Loading';
+import LoadingSpin from '@/components/common/LoadingSpin';
 import Select, { Option } from '@/components/common/Select';
 import { useFolderList } from '@/hooks/queries/useFetchFolderList';
 import { Folder } from '@/pages/mypage/investor/InvestorMyPage';
@@ -16,7 +16,7 @@ const FollowModal = ({ onFolderSelect }: FollowModalProps) => {
   if (isLoading) {
     return (
       <div css={contentWrpperStyle}>
-        <Loader />
+        <LoadingSpin />
       </div>
     );
   }

--- a/src/components/page/strategy-detail/ImgSection.tsx
+++ b/src/components/page/strategy-detail/ImgSection.tsx
@@ -11,7 +11,7 @@ interface imgSectionProps {
   name: string;
   id: number;
   isSelected: boolean;
-  isSelfed: boolean;
+  isSelfed?: boolean;
   onSelect: (id: number) => void;
 }
 

--- a/src/components/page/strategy-detail/StrategyHeader.tsx
+++ b/src/components/page/strategy-detail/StrategyHeader.tsx
@@ -133,11 +133,11 @@ export const StrategyHeader = ({
       {(userRole === 'ROLE_ADMIN' && user?.authorized) ||
       (userRole === 'ROLE_TRADER' && user?.memberId === traderId) ? ( // 트레이더 전용 버튼
         <div css={buttonAreaStyle}>
+          <Button size='xs' variant='secondaryGray' width={90} onClick={() => onDelete(id)}>
+            삭제
+          </Button>
           {!isTerminated && (
             <>
-              <Button size='xs' variant='secondaryGray' width={90} onClick={() => onDelete(id)}>
-                삭제
-              </Button>
               <Button
                 size='xs'
                 variant='neutral'

--- a/src/components/page/strategy-detail/StrategyHeader.tsx
+++ b/src/components/page/strategy-detail/StrategyHeader.tsx
@@ -130,7 +130,8 @@ export const StrategyHeader = ({
         <GiCircle size={40} css={circleStyle} />
         <MdOutlineShare size={16} css={shareStyle} />
       </button>
-      {userRole === 'ROLE_ADMIN' || (userRole === 'ROLE_TRADER' && user?.memberId === traderId) ? ( // 트레이더 전용 버튼
+      {(userRole === 'ROLE_ADMIN' && user?.authorized) ||
+      (userRole === 'ROLE_TRADER' && user?.memberId === traderId) ? ( // 트레이더 전용 버튼
         <div css={buttonAreaStyle}>
           {!isTerminated && (
             <>
@@ -163,7 +164,8 @@ export const StrategyHeader = ({
             </Button>
           )}
         </div>
-      ) : (
+      ) : null}
+      {userRole === 'ROLE_INVESTOR' && (
         <div css={buttonAreaStyle}>
           <Button
             size='sm'

--- a/src/components/page/strategy-detail/review/ReviewItem.tsx
+++ b/src/components/page/strategy-detail/review/ReviewItem.tsx
@@ -29,8 +29,6 @@ const ReviewItem = ({ review, writerId, onEdit, onDelete }: ReviewItemProps) => 
   const [isEditing, setIsEditing] = useState(false);
   const [updatedContent, setUpdatedContent] = useState(review.content);
 
-  console.log(isAdmin);
-
   const handleEdit = () => {
     if (isEditing) {
       onEdit(review.strategyReviewId, updatedContent.trim());
@@ -51,17 +49,18 @@ const ReviewItem = ({ review, writerId, onEdit, onDelete }: ReviewItemProps) => 
             <span css={userNameStyle}>{review.nickName}</span>
             <span css={dateStyle}>{formatDate(review.writedAt)}</span>
           </div>
-          {(isAdmin || review.writerId === writerId) && (
-            <div css={reviewActionsStyle}>
-              <button css={actionButtonStyle} onClick={handleEdit}>
-                {isEditing ? '완료' : '수정'}
-              </button>
-              <span css={separatorStyle}></span>
-              <button css={actionButtonStyle} onClick={handleDelete}>
-                삭제
-              </button>
-            </div>
-          )}
+          {(isAdmin && user?.authorized) ||
+            (review.writerId === writerId && (
+              <div css={reviewActionsStyle}>
+                <button css={actionButtonStyle} onClick={handleEdit}>
+                  {isEditing ? '완료' : '수정'}
+                </button>
+                <span css={separatorStyle}></span>
+                <button css={actionButtonStyle} onClick={handleDelete}>
+                  삭제
+                </button>
+              </div>
+            ))}
         </div>
         {isEditing ? (
           <textarea

--- a/src/components/page/strategy-detail/review/ReviewItem.tsx
+++ b/src/components/page/strategy-detail/review/ReviewItem.tsx
@@ -3,6 +3,7 @@ import { useState } from 'react';
 import { css } from '@emotion/react';
 
 import Avatar from '@/components/common/Avatar';
+import { useAuthStore } from '@/stores/authStore';
 import theme from '@/styles/theme';
 import { formatDate } from '@/utils/dateFormat';
 
@@ -23,8 +24,12 @@ interface ReviewItemProps {
 }
 
 const ReviewItem = ({ review, writerId, onEdit, onDelete }: ReviewItemProps) => {
+  const { user } = useAuthStore();
+  const isAdmin = user?.role === 'ROLE_ADMIN';
   const [isEditing, setIsEditing] = useState(false);
   const [updatedContent, setUpdatedContent] = useState(review.content);
+
+  console.log(isAdmin);
 
   const handleEdit = () => {
     if (isEditing) {
@@ -46,7 +51,7 @@ const ReviewItem = ({ review, writerId, onEdit, onDelete }: ReviewItemProps) => 
             <span css={userNameStyle}>{review.nickName}</span>
             <span css={dateStyle}>{formatDate(review.writedAt)}</span>
           </div>
-          {review.writerId === writerId && (
+          {(isAdmin || review.writerId === writerId) && (
             <div css={reviewActionsStyle}>
               <button css={actionButtonStyle} onClick={handleEdit}>
                 {isEditing ? '완료' : '수정'}

--- a/src/components/page/strategy-detail/review/ReviewItem.tsx
+++ b/src/components/page/strategy-detail/review/ReviewItem.tsx
@@ -49,18 +49,17 @@ const ReviewItem = ({ review, writerId, onEdit, onDelete }: ReviewItemProps) => 
             <span css={userNameStyle}>{review.nickName}</span>
             <span css={dateStyle}>{formatDate(review.writedAt)}</span>
           </div>
-          {(isAdmin && user?.authorized) ||
-            (review.writerId === writerId && (
-              <div css={reviewActionsStyle}>
-                <button css={actionButtonStyle} onClick={handleEdit}>
-                  {isEditing ? '완료' : '수정'}
-                </button>
-                <span css={separatorStyle}></span>
-                <button css={actionButtonStyle} onClick={handleDelete}>
-                  삭제
-                </button>
-              </div>
-            ))}
+          {(isAdmin && user?.authorized) || review.writerId === writerId ? (
+            <div css={reviewActionsStyle}>
+              <button css={actionButtonStyle} onClick={handleEdit}>
+                {isEditing ? '완료' : '수정'}
+              </button>
+              <span css={separatorStyle}></span>
+              <button css={actionButtonStyle} onClick={handleDelete}>
+                삭제
+              </button>
+            </div>
+          ) : null}
         </div>
         {isEditing ? (
           <textarea

--- a/src/components/page/strategy-detail/table/AnalysisTable.tsx
+++ b/src/components/page/strategy-detail/table/AnalysisTable.tsx
@@ -87,7 +87,7 @@ const AnalysisTable = ({
         <thead>
           <tr css={tableRowStyle}>
             {(mode === 'write' && role === 'ROLE_TRADER' && user?.memberId === userId) ||
-            role === 'ROLE_ADMIN' ? (
+            (role === 'ROLE_ADMIN' && user?.authorized) ? (
               <th css={tableHeadStyle}>
                 <Checkbox
                   checked={selectAll ?? false}
@@ -111,7 +111,7 @@ const AnalysisTable = ({
             analysis?.map((values, idx) => (
               <tr key={`${values.dataId}- ${idx}`} css={tableRowStyle}>
                 {(mode === 'write' && role === 'ROLE_TRADER' && user?.memberId === userId) ||
-                role === 'ROLE_ADMIN' ? (
+                (role === 'ROLE_ADMIN' && user?.authorized) ? (
                   <td css={tableCellStyle}>
                     <Checkbox
                       checked={!!selectedItems?.includes(values.dataId)}
@@ -138,7 +138,7 @@ const AnalysisTable = ({
                 <td css={tableCellStyle}>{values.cumulative_profit_loss.toLocaleString()}</td>
                 <td css={tableCellStyle}>{values.cumulative_profit_loss_rate}%</td>
                 {(mode === 'write' && role === 'ROLE_TRADER' && user?.memberId === userId) ||
-                role === 'ROLE_ADMIN' ? (
+                (role === 'ROLE_ADMIN' && user?.authorized) ? (
                   <td css={tableCellStyle}>
                     <Button
                       variant='secondaryGray'
@@ -160,7 +160,8 @@ const AnalysisTable = ({
             ))
           ) : (
             <tr>
-              {mode === 'write' ? (
+              {(mode === 'write' && role === 'ROLE_TRADER' && user?.memberId === userId) ||
+              (role === 'ROLE_ADMIN' && user?.authorized) ? (
                 <td colSpan={attributes.length + 1} css={noDataStyle}>
                   일간분석 데이터를 추가해주세요.
                   <div css={addArea}>

--- a/src/components/page/strategy-detail/table/InputTable.tsx
+++ b/src/components/page/strategy-detail/table/InputTable.tsx
@@ -25,7 +25,7 @@ const InputTable = ({ data, onChange }: InputAnalysisProps) => {
     field: keyof InputTableProps,
     e: React.ChangeEvent<HTMLInputElement>
   ) => {
-    if (e.target.value.length > 12) {
+    if (e.target.value.length > 20) {
       return;
     }
 

--- a/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
+++ b/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
@@ -7,7 +7,7 @@ import { MdCheck } from 'react-icons/md';
 import ImgSection from '../ImgSection';
 
 import Button from '@/components/common/Button';
-import Loader from '@/components/common/Loading';
+import LoadingSpin from '@/components/common/LoadingSpin';
 import Modal from '@/components/common/Modal';
 import Pagination from '@/components/common/Pagination';
 import Toast from '@/components/common/Toast';
@@ -108,7 +108,7 @@ const AccountVerify = ({ strategyId, role, userId }: AccountProps) => {
   if (isLoading) {
     return (
       <div>
-        <Loader />
+        <LoadingSpin />
       </div>
     );
   }

--- a/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
+++ b/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
@@ -48,7 +48,9 @@ const AccountVerify = ({ strategyId, role, userId }: AccountProps) => {
   const { openModal } = useModalStore();
   const { showToast, message, hideToast, isToastVisible } = useToastStore();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
-  const isSelfed = (role === 'ROLE_TRADER' && userId === user?.memberId) || role === 'ROLE_ADMIN';
+  const isSelfed =
+    (role === 'ROLE_TRADER' && userId === user?.memberId) ||
+    (role === 'ROLE_ADMIN' && user?.authorized);
 
   const handleUploadClick = () => {
     fileInputRef.current?.click();

--- a/src/hooks/queries/useSidebarProfile.ts
+++ b/src/hooks/queries/useSidebarProfile.ts
@@ -3,13 +3,13 @@ import { useQuery } from '@tanstack/react-query';
 import { getSidebarProfile } from '@/api/profile';
 import { useAuthStore } from '@/stores/authStore';
 
-export const useSidebarProfileQuery = () => {
+export const useSidebarProfileQuery = (id?: string) => {
   const { user } = useAuthStore();
   const memberId = user?.memberId;
 
   return useQuery({
-    queryKey: ['personalDetails', memberId],
-    queryFn: () => getSidebarProfile(memberId as string),
+    queryKey: ['personalDetails', memberId, id],
+    queryFn: () => (id ? getSidebarProfile(id) : getSidebarProfile(memberId as string)),
     enabled: !!memberId,
   });
 };

--- a/src/hooks/queries/useStatistics.ts
+++ b/src/hooks/queries/useStatistics.ts
@@ -14,6 +14,7 @@ const useStatistics = (strategyId: number, role: UserRole) => {
       };
     },
     enabled: !!strategyId,
+    retry: false,
   });
 
   return { statistics: data?.statistics, writedAt: data?.writedAt, isLoading, isError };

--- a/src/pages/admin/strategy/StrategyApprovalListPage.tsx
+++ b/src/pages/admin/strategy/StrategyApprovalListPage.tsx
@@ -206,7 +206,12 @@ const StrategyApprovalListPage = () => {
             </tbody>
           </table>
         </div>
-        <Pagination totalPage={totalPages} limit={pageSize} page={currentPage} setPage={setPage} />
+        <Pagination
+          totalPage={totalPages}
+          limit={pageSize}
+          page={currentPage + 1}
+          setPage={setPage}
+        />
       </div>
       <Modal />
       <ContentModal />

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -6,7 +6,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import Loader from '@/components/common/Loading';
 import Modal from '@/components/common/Modal';
 import ScrollToTop from '@/components/common/ScrollToTop';
-import Toast from '@/components/common/Toast';
 import ChartSection from '@/components/page/strategy-detail/chart/ChartSection';
 import FileDownSection from '@/components/page/strategy-detail/FileDownSection';
 import IconTagSection from '@/components/page/strategy-detail/IconTagSection';
@@ -34,7 +33,6 @@ import useFetchStrategyDetail from '@/hooks/queries/useFetchStrategyDetail';
 import useStatistics from '@/hooks/queries/useStatistics';
 import { useAuthStore } from '@/stores/authStore';
 import useModalStore from '@/stores/modalStore';
-import useToastStore from '@/stores/toastStore';
 import theme from '@/styles/theme';
 import { UserRole } from '@/types/route';
 import { StrategyIacentity } from '@/types/strategy';
@@ -58,7 +56,6 @@ const StrategyDetailPage = () => {
     useFetchApproveState(Number(strategyId), role, {
       enabled: strategy?.isApproved === 'N',
     }) || '';
-  const { isToastVisible, hideToast, message, type } = useToastStore();
   const isApproved =
     (dailyAnalysis?.length >= 3 && strategy?.requestAvailable === true) ||
     approveState?.isApproved === 'N';
@@ -231,9 +228,6 @@ const StrategyDetailPage = () => {
         <ReviewSection strategyId={Number(strategyId)} writerId={user?.memberId || ''} />
       </div>
       <Modal />
-      {isToastVisible && (
-        <Toast message={message} type={type} isVisible={isToastVisible} onClose={hideToast} />
-      )}
     </div>
   );
 };

--- a/src/pages/strategy/StrategyDetailPage.tsx
+++ b/src/pages/strategy/StrategyDetailPage.tsx
@@ -198,7 +198,7 @@ const StrategyDetailPage = () => {
               isStrategyApproved={strategy?.isApproved}
               isApprovedState={isApproved}
               isTerminated={isTerminated}
-              isFollowing={strategy?.isFollowed || false}
+              isFollowing={strategy?.isFollowed}
               onApproval={() => {
                 handleApproval(strategy.strategyId, role);
               }}

--- a/src/types/strategyDetail.ts
+++ b/src/types/strategyDetail.ts
@@ -55,7 +55,7 @@ export interface StatisticsProps {
   currentDrawdownRate: number;
   maxDrawdownAmount: number;
   maxDrawdownRate: number;
-  unrealizedProfitLoss: number;
+  averageProfitLoss: number;
   averageProfitLossRate: number;
   maxDailyProfit: number;
   maxDailyProfitRate: number;

--- a/src/utils/statistics.ts
+++ b/src/utils/statistics.ts
@@ -2,7 +2,7 @@
 export const formatLoss = (value: number) => value.toLocaleString();
 
 //23.23223 -> 23.23
-export const formatRate = (value: number) => Math.floor(value * 100) / 100;
+export const formatRate = (value: number) => value.toFixed(2);
 
 export const formatValue = (key: string, value: string | number) => {
   if (typeof value === 'number') {
@@ -12,7 +12,7 @@ export const formatValue = (key: string, value: string | number) => {
       key.endsWith('roa') ||
       key.endsWith('Factor')
     ) {
-      return Math.floor(value * 100) / 100 + '%';
+      return value.toFixed(2) + '%';
     } else if (key.endsWith('Days') || key.endsWith('Period') || key.endsWith('Peak')) {
       const years = Math.floor(value / 365);
       const month = Math.floor((value % 365) / 30);
@@ -20,7 +20,7 @@ export const formatValue = (key: string, value: string | number) => {
       let result = '';
       if (years > 0) result += `${years}년 `;
       if (month > 0) result += `${month}개월 `;
-      if (days >= 0 || days <= 0) result += `${days}일`;
+      if (days >= 0 || days <= 0) result += `${Math.abs(days)}일`;
       return result.trim();
     } else {
       return formatLoss(value);


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

1. 일간분석 등록, 삭제, 엑셀업로드 렌더링 버튼 및 전략 수정, 삭제, 운용종료 버튼, 실계좌 등록, 리뷰 수정 및 삭제 버튼 무조건 관리자로 로그인하면 보이던 분기처리 수정
관리자 로그인 후 인증메일 받아서 인증 확인 후 보이도록 분기처리 수정함
2. 삭제는 운용종료와 상관없이 가능하기 때문에 등록, 승인대기, 승인거부, 승인완료 상관없이 삭제 가능하도록 수정
3. 엑셀업로드, 일간분석 등록, 수정, 삭제 시 다량의 데이터가 들어간 경우 서버에서 연산을 다 때려서 계산해서 프론트로 넘어와야하기 때문에 pending상태가 길어짐, 서버에서 데이터가 넘어오기 전 로딩 스피너로 아직 서버에서 데이터가 넘어오는 중임을 표시 (이거 오늘안에 progress Bar 활용해서 데이터를 불러오는 중입니다.. 라는 글씨와 함께 교체 예정)
4. 일간분석 데이터 등록,수정,삭제 중 에러 발생 시 서버에서 발생한 에러 토스트로 띄우도록 추가
5. 통계 테이블 키값 반영, 일자 절댓값 처리, toFixed(2) 적용
6. 트레이더 프로필 페이지 사이드바 API  반영
7. 팔로우한 전략을 내 폴더에서 확인 시 팔로우한 상태가 풀리는 상태 이슈 해결

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
