### PR TITLE
fix: 로딩스피너 위치 수정, 미인증 상태에서 일간분석 수정 비렌더링 처리

### DIFF
--- a/src/components/page/mypage-investor/myfolder/FollowModal.tsx
+++ b/src/components/page/mypage-investor/myfolder/FollowModal.tsx
@@ -47,6 +47,7 @@ const FollowModal = ({ onFolderSelect }: FollowModalProps) => {
 const contentWrpperStyle = css`
   display: flex;
   flex-direction: column;
+  align-items: center;
   gap: 12px;
   margin-bottom: 8px;
   padding: 0 12px;

--- a/src/components/page/strategy-detail/table/AnalysisTable.tsx
+++ b/src/components/page/strategy-detail/table/AnalysisTable.tsx
@@ -98,7 +98,7 @@ const AnalysisTable = ({
             {attributes.map((item, idx) => (
               <th key={idx} css={tableHeadStyle}>
                 {(mode === 'write' && role === 'ROLE_TRADER' && user?.memberId === userId) ||
-                role === 'ROLE_ADMIN' ||
+                (role === 'ROLE_ADMIN' && user?.authorized) ||
                 item.title !== '수정'
                   ? item.title
                   : null}

--- a/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
+++ b/src/components/page/strategy-detail/tabmenu/AccountVerify.tsx
@@ -107,7 +107,7 @@ const AccountVerify = ({ strategyId, role, userId }: AccountProps) => {
 
   if (isLoading) {
     return (
-      <div>
+      <div css={loadingStyle}>
         <LoadingSpin />
       </div>
     );
@@ -185,6 +185,14 @@ const textStyle = css`
   align-items: center;
   ${theme.textStyle.captions.caption2};
   color: ${theme.colors.gray[500]};
+`;
+
+const loadingStyle = css`
+  display: flex;
+  width: 100%;
+  height: 200px;
+  justify-content: center;
+  align-items: center;
 `;
 
 const buttonArea = css`

--- a/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
+++ b/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
@@ -315,7 +315,11 @@ const DailyAnalysis = ({ strategyId, attributes, userId, role }: AnalysisProps) 
   }, [pagination.currentPage]);
 
   if (isLoading) {
-    return <LoadingSpin />;
+    return (
+      <div css={loadingArea}>
+        <LoadingSpin />
+      </div>
+    );
   }
 
   return (

--- a/src/components/page/strategy-detail/tabmenu/MonthlyAnalysis.tsx
+++ b/src/components/page/strategy-detail/tabmenu/MonthlyAnalysis.tsx
@@ -4,6 +4,7 @@ import { css } from '@emotion/react';
 
 import AnalysisTable, { AnalysisProps } from '../table/AnalysisTable';
 
+import LoadingSpin from '@/components/common/LoadingSpin';
 import Pagination from '@/components/common/Pagination';
 import useFetchMonthlyAnalysis from '@/hooks/queries/useFetchMonthlyAnalysis';
 import usePagination from '@/hooks/usePagination';
@@ -44,7 +45,11 @@ const MonthlyAnalysis = ({ attributes, strategyId, role }: AnalysisProps) => {
   }, [monthlyAnalysis]);
 
   if (isLoading) {
-    return <div>로딩중..</div>;
+    return (
+      <div css={loadingArea}>
+        <LoadingSpin />
+      </div>
+    );
   }
 
   return (
@@ -64,6 +69,12 @@ const MonthlyAnalysis = ({ attributes, strategyId, role }: AnalysisProps) => {
 
 const monthlyStyle = css`
   width: 100%;
+`;
+
+const loadingArea = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 const paginationArea = css`


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

haha 관리자 인증도 받아야하는 분기처리를 수정버튼 렌더링 쪽에 안해줘서.. 큰일날뻔했네요
전략 상세 탭이나 팔로우 모달쪽은 로딩 상태일 때 Loader쓰면 너무 커져서.. 로딩 스피너로 교체했습니다

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
