### PR TITLE
[Fix] 전략 상세 일간분석 데이터 대기 시 로딩스피너에서 progressBar 렌더링으로 교체

### DIFF
--- a/src/components/common/ProgressBar.tsx
+++ b/src/components/common/ProgressBar.tsx
@@ -1,0 +1,82 @@
+import { css, keyframes } from '@emotion/react';
+
+import theme from '@/styles/theme';
+
+const ProgressBar: React.FC<{ progress: number; variant: 'forwards' | 'infinite' }> = ({
+  progress,
+  variant = 'forwards',
+}) => (
+  <div css={containerStyle(variant)}>
+    <div css={progressBarContentStyle}>
+      <div css={progressBarStyle(progress, variant)} />
+    </div>
+  </div>
+);
+
+const progressAnimation = (progress: number) => keyframes`
+  0% {
+    width: 0;
+    background-color: ${theme.colors.teal[400]};
+  }
+  50% {
+    background-color: ${theme.colors.teal[500]};
+  }
+  100% {
+    width: ${progress}%;
+    background-color: ${theme.colors.main.primary};
+  }
+`;
+
+const progressInfiniteAnimation = (progress: number) => keyframes`
+0% {
+  transform: translateX(-100%);
+}
+50% {
+  background-color: ${theme.colors.teal[500]};
+}
+100% {
+width: ${progress}%;
+  transform: translateX(100%);
+}
+`;
+
+const containerStyle = (variant: 'forwards' | 'infinite') => css`
+  width: 100%;
+  max-width: 600px;
+  margin: 0px auto;
+  padding: 20px;
+  border-radius: 6px;
+  background: ${theme.colors.main.white};
+  ${variant === 'forwards' &&
+  css`
+    margin: 40px auto;
+    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.2);
+    outline: 2px solid ${theme.colors.teal[400]};
+  `}
+`;
+
+const progressBarContentStyle = css`
+  width: 100%;
+  max-width: 400px;
+  margin: 0 auto;
+  background: ${theme.colors.gray[200]};
+  border-radius: 10px;
+  overflow: hidden;
+  height: 15px;
+`;
+
+const progressBarStyle = (progress: number, variant: 'forwards' | 'infinite') => css`
+  height: 100%;
+  ${variant === 'forwards' &&
+  css`
+    animation: ${progressAnimation(progress)} 2s ease-in-out forwards;
+    border-radius: 10px;
+  `}
+  ${variant === 'infinite' &&
+  css`
+    background: ${theme.colors.teal[400]};
+    animation: ${progressInfiniteAnimation(progress)} 1.5s ease-in-out infinite;
+  `}
+`;
+
+export default ProgressBar;

--- a/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
+++ b/src/components/page/strategy-detail/tabmenu/DailyAnalysis.tsx
@@ -10,6 +10,7 @@ import TableModal from '../table/TableModal';
 import Button from '@/components/common/Button';
 import LoadingSpin from '@/components/common/LoadingSpin';
 import Pagination from '@/components/common/Pagination';
+import ProgressBar from '@/components/common/ProgressBar';
 import Toast from '@/components/common/Toast';
 import {
   useDeleteAllAnalysis,
@@ -24,6 +25,7 @@ import { useAuthStore } from '@/stores/authStore';
 import useModalStore from '@/stores/modalStore';
 import useTableModalStore from '@/stores/tableModalStore';
 import useToastStore from '@/stores/toastStore';
+import theme from '@/styles/theme';
 import { UserRole } from '@/types/route';
 import { DailyAnalysisProps, AnalysisDataProps } from '@/types/strategyDetail';
 import { isValidInputNumber, isValidPossibleDate } from '@/utils/statistics';
@@ -48,6 +50,12 @@ const DailyAnalysis = ({ strategyId, attributes, userId, role }: AnalysisProps) 
     pagination.pageSize,
     role as UserRole
   );
+  const isPending =
+    postStatus === 'pending' ||
+    putStatus === 'pending' ||
+    deleteStatus === 'pending' ||
+    uploadStatus === 'pending' ||
+    alldeleteStatus === 'pending';
 
   const normalizedData = useMemo(() => {
     if (!dailyAnalysis) return [];
@@ -391,14 +399,10 @@ const DailyAnalysis = ({ strategyId, attributes, userId, role }: AnalysisProps) 
             </div>
           </div>
         )}
-      {postStatus === 'pending' ||
-      putStatus === 'pending' ||
-      deleteStatus === 'pending' ||
-      uploadStatus === 'pending' ||
-      alldeleteStatus === 'pending' ? (
+      {isPending ? (
         <div css={loadingArea}>
-          {' '}
-          <LoadingSpin />
+          <div css={loadingText}>작업을 진행중입니다.</div>
+          <ProgressBar variant='infinite' progress={100} />
         </div>
       ) : (
         <>
@@ -441,8 +445,16 @@ const dailyStyle = css`
 
 const loadingArea = css`
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  color: ${theme.colors.gray[400]};
+  ${theme.textStyle.subtitles.subtitle4};
+`;
+
+const loadingText = css`
+  display: flex;
+  margin-top: 40px;
 `;
 
 const addArea = css`


### PR DESCRIPTION
…gressBar로 교체

# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

전략 상세 일간분석 탭에서 일간분석 등록, 수정, 삭제, 엑셀업로드 시 서버에서 연산되어서 오는 시간동안 보여줄  로딩 화면 필요
임시로 로딩 스피너 처리했던 부분 progressBar로 교체
탭 부분에서는 기존의 progressBar보다 borderLine 및 그림자가 없이 가는게 더 나을 것 같아 타입 나눠서 기존꺼 forward로 두고 하나 infinite로 만들어서 수정함


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

![Dec-08-2024 16-32-34](https://github.com/user-attachments/assets/5a6a3a5d-916a-455d-838b-da585c4a0e0e)


## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
