### PR TITLE
[Feat] 트레이더 목록 sort, 메인페이지 팔로워 랭킹 api 연동

### DIFF
--- a/src/api/apiEndpoints.ts
+++ b/src/api/apiEndpoints.ts
@@ -35,6 +35,7 @@ export const API_ENDPOINTS = {
     TRADER_STATS: '/api/strategies/strategy-trader-count', //트레이더 통계조회 (트레이더 수, 전략 수)
     UPLOAD_ACCOUNT_IMG: '/api/live-account-data', //실계좌 이미지 관리
     SM_SCORE: '/api/strategies/top5-sm-score', // 메인페이지 SMScore Top5
+    FOLLOWING_RANKING: '/api/strategies/follower-ranking', // 팔로우 랭킹
     REVIEWS: (strategyId: number) => `/api/strategies/${strategyId}/reviews`, // 리뷰(전략상세하단)
   },
   TRADERS: {

--- a/src/api/home/followRanking.ts
+++ b/src/api/home/followRanking.ts
@@ -1,0 +1,15 @@
+import apiClient from '@/api/apiClient';
+import { API_ENDPOINTS } from '@/api/apiEndpoints';
+
+export const fetchFollowerRanking = async (size: number) => {
+  try {
+    const { data } = await apiClient.get(API_ENDPOINTS.STRATEGY.FOLLOWING_RANKING, {
+      params: {
+        size,
+      },
+    });
+    return data.data;
+  } catch (error) {
+    console.error('Failed to fetch follower ranking:', error);
+  }
+};

--- a/src/api/search.ts
+++ b/src/api/search.ts
@@ -15,7 +15,7 @@ interface SearchParams {
   keyword?: string;
   page?: number;
   pageSize?: number;
-  sortOption?: 'strategyCnt' | 'latestSignup';
+  sortOption?: 'strategyCnt' | 'latestSignup' | 'followerCnt';
 }
 
 // 키보드 입력에 따른 '전체 트레이더' 검색 결과를 보여주는 경우 - 트레이더 검색

--- a/src/components/common/TraderList.tsx
+++ b/src/components/common/TraderList.tsx
@@ -13,6 +13,7 @@ interface TraderData {
   description: string;
   strategiesCount: number;
   createdAt: string; // 필요한지 확인 필요
+  followerCnt: number;
 }
 
 interface TraderListProps {
@@ -42,7 +43,7 @@ const TraderList = ({ traders, badgeRank }: TraderListProps) => {
             <Avatar src={trader.profileImage} alt='프로필이미지' size={50} />
             {badgeRank?.includes(trader.traderId) && (
               <div css={badgeStyle}>
-                {badgeRank.indexOf(trader.traderId) + 1} {/* 순위 계산 */}
+                {trader.followerCnt} {/* 순위 계산 */}
               </div>
             )}
           </div>

--- a/src/components/page/mypage-investor/myfolder/FolderModal.tsx
+++ b/src/components/page/mypage-investor/myfolder/FolderModal.tsx
@@ -3,7 +3,7 @@ import { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 
 import Input from '@/components/common/Input';
-import Loader from '@/components/common/Loading';
+import LoadingSpin from '@/components/common/LoadingSpin';
 import Select, { Option } from '@/components/common/Select';
 import { useFolderList } from '@/hooks/queries/useFetchFolderList';
 import { Folder } from '@/pages/mypage/investor/InvestorMyPage';
@@ -37,14 +37,14 @@ const FolderModal = ({
 
   if (isLoading) {
     return (
-      <div css={contentWrpperStyle}>
-        <Loader />
+      <div css={loaderStyle}>
+        <LoadingSpin />
       </div>
     );
   }
 
   if (isError || !data || !data.data) {
-    return <div css={contentWrpperStyle}>폴더 데이터를 불러오지 못했습니다.</div>;
+    return <div css={loaderStyle}>폴더 데이터를 불러오지 못했습니다.</div>;
   }
 
   const folder = data?.data.map((item: Folder) => ({
@@ -98,6 +98,13 @@ const contentWrpperStyle = css`
     color: ${theme.colors.main.primary};
     text-align: left;
   }
+`;
+
+const loaderStyle = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 40px 0;
 `;
 
 export default FolderModal;

--- a/src/components/page/strategy/StrategyForm.tsx
+++ b/src/components/page/strategy/StrategyForm.tsx
@@ -3,6 +3,7 @@ import { useState, useEffect } from 'react';
 import { css } from '@emotion/react';
 
 import Button from '@/components/common/Button';
+import Loader from '@/components/common/Loading';
 import Modal from '@/components/common/Modal';
 import Select from '@/components/common/Select';
 import FileUpload from '@/components/page/strategy/form-content/FileUpload';
@@ -162,7 +163,13 @@ const StrategyForm = ({
     handleSubmit();
   };
 
-  if (loading) return <p>Loading.....</p>;
+  if (loading)
+    return (
+      <div css={formContainerStyle}>
+        <Loader />
+      </div>
+    );
+
   if (error) return <p>{error}</p>;
 
   return (

--- a/src/hooks/queries/useFetchFollowerRanking.ts
+++ b/src/hooks/queries/useFetchFollowerRanking.ts
@@ -1,0 +1,19 @@
+import { useQuery } from '@tanstack/react-query';
+
+import { fetchFollowerRanking } from '@/api/home/followRanking';
+
+export const useFetchFollowerRanking = (size: number) => {
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['followerRanking', size],
+    queryFn: async () => {
+      try {
+        return await fetchFollowerRanking(size);
+      } catch (error) {
+        console.error('failed to fetch follower ranking', error);
+        throw error;
+      }
+    },
+  });
+
+  return { data, isLoading, isError };
+};

--- a/src/hooks/queries/useSearch.ts
+++ b/src/hooks/queries/useSearch.ts
@@ -11,7 +11,7 @@ import {
 
 export const useSearchTraders = (
   keyword?: string, // 옵셔널
-  sortOption: 'strategyCnt' | 'latestSignup' = 'strategyCnt',
+  sortOption: 'strategyCnt' | 'latestSignup' | 'followerCnt' = 'strategyCnt',
   options: { page?: number; pageSize?: number } = {}
 ): UseQueryResult<SearchResponse<SearchedTrader>> => {
   console.log('useSearchTraders Hook Parameters:', { keyword, sortOption });

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -125,9 +125,6 @@ const HomePage = () => {
               </div>
             ))}
           </div>
-          <div css={descriptionContainerStyle}>
-            <p css={descriptionStyle}>트레이더의 누적 수익 금액입니다.</p>
-          </div>
         </div>
       </section>
       {/* 트레이더Main */}

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -2,22 +2,30 @@ import { css } from '@emotion/react';
 import { MdKeyboardArrowRight, MdArrowForward } from 'react-icons/md';
 import { useNavigate } from 'react-router-dom';
 
-import TraderUserImage3 from '@/assets/images/ani_trader.png';
-import TraderUserImage1 from '@/assets/images/apt_trader.png';
 import EverageMetricsChartImage from '@/assets/images/everage_metrics_chart.png';
 import InvestorMainImage from '@/assets/images/investor_main.png';
-import TraderUserImage2 from '@/assets/images/nimo_trader.png';
 import TraderMainImage from '@/assets/images/trader_main.png';
+import Avatar from '@/components/common/Avatar';
 import Button from '@/components/common/Button';
 import Loader from '@/components/common/Loading';
 import ScrollToTop from '@/components/common/ScrollToTop';
 import TraderStats from '@/components/page/home/StrategyTraderCount';
 import TopStrategyList from '@/components/page/home/TopStrategyList';
 import { ROUTES } from '@/constants/routes';
+import { useFetchFollowerRanking } from '@/hooks/queries/useFetchFollowerRanking';
 import { useFetchStrategyTraderCount } from '@/hooks/queries/useFetchStrategyTraderCount';
 import { useFetchTopStrategy } from '@/hooks/queries/useFetchTopStrategy';
 import { useAuthStore } from '@/stores/authStore';
 import theme from '@/styles/theme';
+
+interface FollowerRankingData {
+  memberId: string;
+  followerCnt: number;
+  introduction: string;
+  nickname: string;
+  strategyCnt: number;
+  profilePath: string;
+}
 
 const HomePage = () => {
   const navigate = useNavigate();
@@ -25,13 +33,21 @@ const HomePage = () => {
   // 훅 호출
   const { data: strategyData, isLoading: isLoadingStrategy } = useFetchStrategyTraderCount();
   const { data: rankingData, isLoading: isLoadingRanking } = useFetchTopStrategy();
+  const { data: followerRankingData, isLoading: isLoadingFollower } = useFetchFollowerRanking(3);
 
   // 트레이더 및 전략 수 표시를 위한 데이터 처리
   const traderCount = Number(strategyData?.traderCnt ?? 0);
   const strategyCount = Number(strategyData?.strategyCnt ?? 0);
 
+  const getOrdinalSuffix = (num: number) => {
+    if (num === 1) return 'st';
+    if (num === 2) return 'nd';
+    if (num === 3) return 'rd';
+    return 'th';
+  };
+
   // 로딩 처리
-  if (isLoadingStrategy || isLoadingRanking) {
+  if (isLoadingStrategy || isLoadingRanking || isLoadingFollower) {
     return <Loader />;
   }
 
@@ -88,39 +104,26 @@ const HomePage = () => {
                 <MdArrowForward css={arrowForwardStyle} />
               </button>
             </div>
-            <div css={rankingItemStyle}>
-              <div css={rankWithIconStyle}>
-                <h3 css={rankTextStyle}>1st</h3>
-                <MdKeyboardArrowRight css={arrowIconStyle} />
+            {followerRankingData.map((ranking: FollowerRankingData, idx: number) => (
+              <div css={rankingItemStyle} key={ranking?.memberId}>
+                <div css={rankWithIconStyle}>
+                  <h3 css={rankTextStyle}>
+                    {idx + 1}
+                    {getOrdinalSuffix(idx + 1)}
+                  </h3>
+                  <MdKeyboardArrowRight css={arrowIconStyle} />
+                </div>
+                <div css={userInfoStyle}>
+                  <Avatar src={ranking.profilePath} alt={ranking.nickname} size={50} />
+                  <p css={traderNameStyle}>{ranking.nickname}</p>
+                </div>
+                <span css={amountTextStyle}>
+                  팔로워
+                  <p>{ranking.followerCnt}</p>| 전략
+                  <p>{ranking.strategyCnt}</p>
+                </span>
               </div>
-              <div css={userInfoStyle}>
-                <img src={TraderUserImage1} alt='아파트수집가' css={userImageStyle} />
-                <p css={traderNameStyle}>아파트수집가</p>
-              </div>
-              <span css={amountTextStyle}>137,031,335원</span>
-            </div>
-            <div css={rankingItemStyle}>
-              <div css={rankWithIconStyle}>
-                <h3 css={rankTextStyle}>2nd</h3>
-                <MdKeyboardArrowRight css={arrowIconStyle} />
-              </div>
-              <div css={userInfoStyle}>
-                <img src={TraderUserImage2} alt='제로니모' css={userImageStyle} />
-                <p css={traderNameStyle}>제로니모</p>
-              </div>
-              <span css={amountTextStyle}>29,852,370원</span>
-            </div>
-            <div css={rankingItemStyle}>
-              <div css={rankWithIconStyle}>
-                <h3 css={rankTextStyle}>3rd</h3>
-                <MdKeyboardArrowRight css={arrowIconStyle} />
-              </div>
-              <div css={userInfoStyle}>
-                <img src={TraderUserImage3} alt='애니헬프' css={userImageStyle} />
-                <p css={traderNameStyle}>애니헬프</p>
-              </div>
-              <span css={amountTextStyle}>29,266,720원</span>
-            </div>
+            ))}
           </div>
           <div css={descriptionContainerStyle}>
             <p css={descriptionStyle}>트레이더의 누적 수익 금액입니다.</p>
@@ -308,8 +311,8 @@ const arrowIconStyle = css`
 
 const userInfoStyle = css`
   display: flex;
-  align-items: center;
-  gap: 8px;
+  flex-direction: column;
+  gap: 12px;
 `;
 
 const traderNameStyle = css`
@@ -317,22 +320,18 @@ const traderNameStyle = css`
   ${theme.textStyle.subtitles.subtitle2};
 `;
 
-const userImageStyle = css`
-  width: 48px;
-  height: 48px;
-  border-radius: 50%;
-  border: 1px solid ${theme.colors.main.white};
-  position: relative;
-  margin-left: -12px;
-  &:first-of-type {
-    margin-left: 0;
-  }
-`;
-
 const amountTextStyle = css`
-  ${theme.textStyle.subtitles.subtitle1};
+  /* ${theme.textStyle.subtitles.subtitle1}; */
+  font-size: 18px;
   color: ${theme.colors.gray[900]};
   text-align: center;
+  display: flex;
+  gap: 8px;
+
+  p {
+    display: flex;
+    color: ${theme.colors.main.primary};
+  }
 `;
 
 const descriptionContainerStyle = css`

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -331,17 +331,6 @@ const amountTextStyle = css`
   }
 `;
 
-const descriptionContainerStyle = css`
-  width: 100%;
-  text-align: right;
-  margin-top: 16px;
-`;
-
-const descriptionStyle = css`
-  ${theme.textStyle.captions.caption2};
-  color: ${theme.colors.gray[400]};
-`;
-
 /* 트레이더Main */
 
 const traderSectionStyle = css`

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -53,14 +53,17 @@ const HomePage = () => {
 
   const handleSignUpClick = () => {
     navigate(ROUTES.AUTH.SIGNUP.SELECT_TYPE);
+    window.scrollTo(0, 0);
   };
 
   const handleStrategyListClick = () => {
     navigate(ROUTES.STRATEGY.LIST);
+    window.scrollTo(0, 0);
   };
 
   const handleTraderListClick = () => {
     navigate(ROUTES.TRADER.LIST);
+    window.scrollTo(0, 0);
   };
 
   return (

--- a/src/pages/mypage/investor/InvestorFollowFolderPage.tsx
+++ b/src/pages/mypage/investor/InvestorFollowFolderPage.tsx
@@ -6,6 +6,7 @@ import { useParams } from 'react-router-dom';
 import { unfollowStrategy, updateFollowingFolder } from '@/api/follow';
 import ContentModal from '@/components/common/ContentModal';
 import Loader from '@/components/common/Loading';
+import LoadingSpin from '@/components/common/LoadingSpin';
 import Pagination from '@/components/common/Pagination';
 import StrategyList from '@/components/common/StrategyList';
 import Toast from '@/components/common/Toast';

--- a/src/pages/mypage/investor/InvestorFollowFolderPage.tsx
+++ b/src/pages/mypage/investor/InvestorFollowFolderPage.tsx
@@ -6,7 +6,6 @@ import { useParams } from 'react-router-dom';
 import { unfollowStrategy, updateFollowingFolder } from '@/api/follow';
 import ContentModal from '@/components/common/ContentModal';
 import Loader from '@/components/common/Loading';
-import LoadingSpin from '@/components/common/LoadingSpin';
 import Pagination from '@/components/common/Pagination';
 import StrategyList from '@/components/common/StrategyList';
 import Toast from '@/components/common/Toast';

--- a/src/pages/trader/TraderDetailPage.tsx
+++ b/src/pages/trader/TraderDetailPage.tsx
@@ -44,7 +44,7 @@ const TraderDetailPage = () => {
 
   if (isLoading) {
     return (
-      <div css={myPageWrapperStyle}>
+      <div css={loaderStyle}>
         <Loader />
       </div>
     );
@@ -52,7 +52,7 @@ const TraderDetailPage = () => {
 
   if (isError) {
     return (
-      <div css={myPageWrapperStyle}>
+      <div css={loaderStyle}>
         <p css={emptyStateWrapperStyle}>
           데이터를 불러오는 데 실패했습니다. <br /> 다시 시도하거나 잠시 후에 확인해주세요.
         </p>
@@ -184,6 +184,12 @@ const emptyStateWrapperStyle = css`
   height: 200px;
   text-align: center;
   color: ${theme.colors.gray[400]};
+`;
+
+const loaderStyle = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 export default TraderDetailPage;

--- a/src/pages/trader/TraderListPage.tsx
+++ b/src/pages/trader/TraderListPage.tsx
@@ -32,7 +32,11 @@ const TraderListPage = () => {
   const mappedTraders = traderResults?.data.map(mapToTraderData) ?? [];
 
   if (isTraderLoading) {
-    return <Loader />;
+    return (
+      <div css={loaderStyle}>
+        <Loader />
+      </div>
+    );
   }
   return (
     <div>
@@ -48,6 +52,7 @@ const TraderListPage = () => {
               setSortOption(option.value as 'strategyCnt' | 'latestSignup' | 'followerCnt');
               setCurrentPage(1); // 정렬 변경시 첫 페이지로 이동
             }}
+            value={sortOptions.find((option) => option.value === sortOption)}
             type='sm'
             width='200px'
             defaultLabel='전략 많은 순'
@@ -97,6 +102,12 @@ const listContainerStyle = css`
   display: flex;
   flex-direction: column;
   gap: 24px;
+`;
+
+const loaderStyle = css`
+  display: flex;
+  justify-content: center;
+  align-items: center;
 `;
 
 export default TraderListPage;

--- a/src/pages/trader/TraderListPage.tsx
+++ b/src/pages/trader/TraderListPage.tsx
@@ -16,10 +16,13 @@ const desc = [{ text: '관심 있는 트레이더를 찾아 전략과 프로필�
 const sortOptions = [
   { label: '전략 많은 순', value: 'strategyCnt' },
   { label: '신규 등록 순', value: 'latestSignup' },
+  { label: '팔로워 많은 순', value: 'followerCnt' },
 ];
 
 const TraderListPage = () => {
-  const [sortOption, setSortOption] = useState<'strategyCnt' | 'latestSignup'>('strategyCnt');
+  const [sortOption, setSortOption] = useState<'strategyCnt' | 'latestSignup' | 'followerCnt'>(
+    'strategyCnt'
+  );
   const [currentPage, setCurrentPage] = useState(1); // 현재 페이지
   const { data: traderResults, isLoading: isTraderLoading } = useSearchTraders('', sortOption, {
     page: currentPage - 1, // 페이지는 0부터 시작
@@ -42,7 +45,7 @@ const TraderListPage = () => {
           <Select
             options={sortOptions}
             onChange={(option) => {
-              setSortOption(option.value as 'strategyCnt' | 'latestSignup');
+              setSortOption(option.value as 'strategyCnt' | 'latestSignup' | 'followerCnt');
               setCurrentPage(1); // 정렬 변경시 첫 페이지로 이동
             }}
             type='sm'

--- a/src/types/search.ts
+++ b/src/types/search.ts
@@ -5,6 +5,7 @@ export interface SearchedTrader {
   fileId: string;
   profilePath: string | null;
   strategyCnt: number;
+  followerCnt: number;
 }
 
 export interface SearchedStrategy {

--- a/src/utils/mappers.ts
+++ b/src/utils/mappers.ts
@@ -6,6 +6,7 @@ export const mapToTraderData = (trader: SearchedTrader) => ({
   profileImage: trader.profilePath || '',
   description: trader.introduction || '',
   strategiesCount: trader.strategyCnt,
+  followerCnt: trader.followerCnt,
   createdAt: new Date().toISOString(), // 또는 API에서 받아온 데이터 사용
 });
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

- 트레이더 목록 페이지 팔로워 많은 순 api 추가
- 메인페이지 팔로우 랭킹 api 연동 및 css 수정 (누적수익금 사라짐)
- 로딩 컴포넌트 수정


## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
