### PR TITLE
[Fix] 비로그인 트레이더 프로필 조회 뒤로가기 안되는 버그 해결

### DIFF
--- a/src/pages/trader/TraderDetailPage.tsx
+++ b/src/pages/trader/TraderDetailPage.tsx
@@ -33,7 +33,7 @@ const TraderDetailPage = () => {
   useEffect(() => {
     if (!user) {
       showToast('로그인이 필요한 서비스 입니다.', 'error');
-      navigate(ROUTES.AUTH.SIGNIN);
+      navigate(ROUTES.AUTH.SIGNIN, { replace: true });
     }
   }, [user]);
 


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- 이슈 지울때 작성해 주세요. -->
<!-- closes #issue-number -->
<!-- 이슈 여러 개 일 경우, closes #1, closes #2 -->
<!-- https://docs.github.com/ko/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue -->

## 📋 작업 내용

비로그인 트레이더 프로필 조회 뒤로가기시 페이지 이동 안되는 버그 해결

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

주요 변경 사항을 요약해 주세요.

## 📸 스크린샷 (선택 사항)

수정된 화면 또는 기능을 시연할 수 있는 스크린샷을 첨부해 주세요.

## 📄 기타

추가적으로 전달하고 싶은 내용이나 특별한 요구 사항이 있으면 작성해 주세요.
