### PR TITLE
[refactor] Input 컴포넌트 리팩토링 및 TextField 통합

### DIFF
--- a/src/components/common/BaseInput.tsx
+++ b/src/components/common/BaseInput.tsx
@@ -1,33 +1,32 @@
-import { InputHTMLAttributes } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 
 import { css, SerializedStyles } from '@emotion/react';
 
 import theme from '@/styles/theme';
 
-export type InputSize = 'small' | 'medium' | 'large';
+export type InputSize = 'sm' | 'md' | 'lg';
 export type InputStatus = 'default' | 'error' | 'success';
 
 export interface BaseInputProps extends InputHTMLAttributes<HTMLInputElement> {
-  variant?: InputSize;
+  inputSize?: InputSize;
   status?: InputStatus;
   customStyle?: SerializedStyles;
 }
 
-const BaseInput: React.FC<BaseInputProps> = ({
-  variant = 'medium',
-  status = 'default',
-  customStyle,
-  ...props
-}) => {
-  const currentInputStyles = [
-    baseInputStyles,
-    inputSizeStyles[variant],
-    inputStatusStyles[status],
-    customStyle,
-  ];
+const BaseInput = forwardRef<HTMLInputElement, BaseInputProps>(
+  ({ inputSize = 'md', status = 'default', customStyle, ...props }, ref) => {
+    const currentInputStyles = [
+      baseInputStyles,
+      inputSizeStyles[inputSize],
+      inputStatusStyles[status],
+      customStyle,
+    ];
 
-  return <input {...props} css={currentInputStyles} />;
-};
+    return <input ref={ref} {...props} css={currentInputStyles} />;
+  }
+);
+
+BaseInput.displayName = 'BaseInput';
 
 export default BaseInput;
 
@@ -60,17 +59,17 @@ const baseInputStyles = css`
 `;
 
 const inputSizeStyles = {
-  small: css`
+  sm: css`
     height: ${theme.input.height.sm};
     padding: ${theme.input.padding.sm};
     font-size: ${theme.input.fontSize.sm};
   `,
-  medium: css`
+  md: css`
     height: ${theme.input.height.md};
     padding: ${theme.input.padding.md};
     font-size: ${theme.input.fontSize.md};
   `,
-  large: css`
+  lg: css`
     height: ${theme.input.height.lg};
     padding: ${theme.input.padding.lg};
     font-size: ${theme.input.fontSize.lg};

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,16 +1,16 @@
 import React, { forwardRef, RefObject, useEffect, useState } from 'react';
 
 import { css, SerializedStyles } from '@emotion/react';
-import { FiSearch } from 'react-icons/fi'; // 검색 아이콘
-import { GrMailOption } from 'react-icons/gr'; // 메일 아이콘
-import { IoIosCloseCircle, IoMdEye, IoMdEyeOff } from 'react-icons/io'; // 키, 눈, 닫기 아이콘
+import { FiSearch } from 'react-icons/fi';
+import { GrMailOption } from 'react-icons/gr';
+import { IoIosCloseCircle, IoMdEye, IoMdEyeOff } from 'react-icons/io';
 import { RiKeyFill } from 'react-icons/ri';
 
+import BaseInput from '@/components/common/BaseInput';
 import theme from '@/styles/theme';
 
-export type InputSize = 'sm' | 'md' | 'lg'; // input 높이 사이즈
+export type InputSize = 'sm' | 'md' | 'lg';
 export type InputStatus = 'default' | 'error' | 'success';
-export type IconPosition = 'left' | 'right';
 
 export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   inputSize?: InputSize;
@@ -21,7 +21,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   showClearButton?: boolean;
   isDisabled?: boolean;
   ref?: RefObject<HTMLInputElement>;
-  customStyle?: SerializedStyles; // 사용되는 페이지에서 추가적인 스타일을 적용할 때 사용
+  customStyle?: SerializedStyles;
   validate?: (value: string) => { isValid: boolean; message: string };
   onInputValidation?: (isValid: boolean) => void;
 }
@@ -36,15 +36,16 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     showClearButton = false,
     isDisabled = false,
     customStyle,
-    validate, // 입력값 검증 함수
-    onInputValidation, // 입력값 검증 결과 콜백 함수
+    validate,
+    onInputValidation,
     ...inputProps
   } = props;
-  const [inputValue, setInputValue] = useState<string>((props.value as string) || '');
   const [inputStatus, setInputStatus] = useState<InputStatus>(status);
   const [showPassword, setShowPassword] = useState<boolean>(false);
 
-  // 아이콘에 따른 아이콘 컴포넌트 반환
+  const inputValue = (props.value as string) || '';
+
+  // 아이콘 매핑
   const getIcon = (iconName: string) => {
     switch (iconName) {
       case 'mail':
@@ -67,7 +68,6 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
   }, [status]);
 
   useEffect(() => {
-    // validate 함수가 존재하고 inputValue가 존재할 때 validation 체크
     if (validate && inputValue) {
       const validationResult = validate(inputValue);
       setInputStatus(validationResult.isValid ? 'success' : 'error');
@@ -75,15 +75,11 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     }
   }, [inputValue, validate, onInputValidation]);
 
-  // input 값이 변경될 때
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setInputValue(e.target.value);
-    inputProps.onChange?.(e); // 부모 컴포넌트로 이벤트 전달
+    inputProps.onChange?.(e);
   };
 
-  // input clear 버튼 클릭 시
   const handleClear = () => {
-    setInputValue('');
     setInputStatus('default');
     if (inputProps.onChange) {
       const event = new Event('input', {
@@ -94,42 +90,21 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     }
   };
 
-  // input type이 password일 때, 눈 아이콘 클릭 시(토글)
   const handleTogglePassword = () => {
     setShowPassword((prev) => !prev);
   };
 
-  // width 값을 처리하는 함수 추가
-  const getWidthStyle = (width: string | number) => {
-    if (typeof width === 'number') {
-      return `width: ${width}px;`;
-    }
-    return width;
-  };
-
-  // container 스타일에 width를 동적으로 적용
-  const currentContainerStyles = css`
-    ${containerStyles};
-    width: ${getWidthStyle(width)};
+  const dynamicPaddingStyles = css`
+    ${leftIcon && 'padding-left: 36px;'}
+    ${(rightIcon || (showClearButton && inputValue)) && 'padding-right: 36px;'}
   `;
 
-  // input 상태에 따른 스타일 적용
-  const currentInputStyles = [
-    baseInputStyles, // 기본 input 스타일
-    inputSizeStyles[inputSize], // input 사이즈에 따른 스타일
-    inputStatusStyles[inputStatus], // input 상태에 따른 스타일
-    leftIcon && paddingLeftStyles, // leftIcon이 있을 때 padding 적용
-    // rightIcon이 있거나 (leftIcon과 showClearButton이 모두 있고 inputValue가 있을 때)만 오른쪽 패딩 적용
-    (rightIcon || (leftIcon && showClearButton && inputValue)) && paddingRightStyles,
-    customStyle,
-  ];
-
   return (
-    <div css={[containerStyles, currentContainerStyles]}>
+    <div css={containerStyles} style={{ width: typeof width === 'number' ? `${width}px` : width }}>
       <div css={[wrapperStyles, iconSpacingStyles[inputSize]]}>
         {leftIcon && <div css={leftIconStyles}>{getIcon(leftIcon)}</div>}
 
-        <input
+        <BaseInput
           {...inputProps}
           ref={ref}
           type={
@@ -137,8 +112,13 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
           }
           value={inputValue}
           disabled={isDisabled}
-          css={currentInputStyles}
+          inputSize={inputSize}
+          status={inputStatus}
           onChange={handleInputChange}
+          customStyle={css`
+            ${dynamicPaddingStyles}
+            ${customStyle}
+          `}
         />
 
         {showClearButton && inputValue && inputStatus !== 'success' && (
@@ -156,6 +136,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     </div>
   );
 });
+
 Input.displayName = 'Input';
 
 const containerStyles = css`
@@ -170,56 +151,10 @@ const wrapperStyles = css`
   width: 100%;
 `;
 
-const baseInputStyles = css`
-  width: 100%;
-  border: 1px solid ${theme.colors.gray[300]};
-  background-color: ${theme.colors.main.white};
-  outline: none;
-  transition: all 0.2s ease;
-  font-family: 'Pretendard', sans-serif;
-  line-height: 150%;
-
-  &::placeholder {
-    color: ${theme.colors.gray[700] + '4a'};
-    font-weight: ${theme.typography.fontWeight.regular};
-  }
-
-  &:hover:not(:disabled) {
-    border-color: ${theme.colors.main.primary};
-  }
-
-  &:focus:not(:disabled) {
-    border-color: ${theme.colors.main.primary};
-  }
-
-  &:disabled {
-    background-color: ${theme.colors.gray[100]};
-    cursor: not-allowed;
-  }
-`;
-
-const inputSizeStyles = {
-  sm: css`
-    height: ${theme.input.height.sm};
-    padding: ${theme.input.padding.sm};
-    font-size: ${theme.input.fontSize.sm};
-  `,
-  md: css`
-    height: ${theme.input.height.md};
-    padding: ${theme.input.padding.md};
-    font-size: ${theme.input.fontSize.md};
-  `,
-  lg: css`
-    height: ${theme.input.height.lg};
-    padding: ${theme.input.padding.lg};
-    font-size: ${theme.input.fontSize.lg};
-  `,
-};
-
 const iconSpacingStyles = {
   sm: css`
     svg {
-      color: ${theme.colors.gray[400]}; //#a1a1aa
+      color: ${theme.colors.gray[400]};
       width: 20px;
       height: 20px;
     }
@@ -237,24 +172,6 @@ const iconSpacingStyles = {
       width: 24px;
       height: 24px;
     }
-  `,
-};
-
-const inputStatusStyles = {
-  default: css``,
-  error: css`
-    border-color: ${theme.colors.main.alert};
-
-    &:hover:not(:disabled) {
-      border-color: ${theme.colors.main.alert};
-    }
-
-    &:focus:not(:disabled) {
-      border-color: ${theme.colors.main.alert};
-    }
-  `,
-  success: css`
-    border-color: ${theme.colors.gray[400]};
   `,
 };
 
@@ -282,14 +199,6 @@ const leftIconStyles = css`
 const rightIconStyles = css`
   ${iconButtonStyles}
   right: 12px;
-`;
-
-const paddingLeftStyles = css`
-  padding-left: 36px;
-`;
-
-const paddingRightStyles = css`
-  padding-right: 36px;
 `;
 
 export default Input;

--- a/src/components/common/Input.tsx
+++ b/src/components/common/Input.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, RefObject, useEffect, useState } from 'react';
 
 import { css, SerializedStyles } from '@emotion/react';
-import { FiSearch } from 'react-icons/fi';
 import { GrMailOption } from 'react-icons/gr';
 import { IoIosCloseCircle, IoMdEye, IoMdEyeOff } from 'react-icons/io';
 import { RiKeyFill } from 'react-icons/ri';
@@ -16,7 +15,7 @@ export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> 
   inputSize?: InputSize;
   width?: string | number;
   status?: InputStatus;
-  leftIcon?: 'mail' | 'key' | 'search';
+  leftIcon?: 'mail' | 'key';
   rightIcon?: 'eye' | 'clear';
   showClearButton?: boolean;
   isDisabled?: boolean;
@@ -40,6 +39,8 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     onInputValidation,
     ...inputProps
   } = props;
+
+  // UI 상태만 관리
   const [inputStatus, setInputStatus] = useState<InputStatus>(status);
   const [showPassword, setShowPassword] = useState<boolean>(false);
 
@@ -56,17 +57,17 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
         return showPassword ? <IoMdEyeOff /> : <IoMdEye />;
       case 'clear':
         return <IoIosCloseCircle />;
-      case 'search':
-        return <FiSearch />;
       default:
         return null;
     }
   };
 
+  // status prop 변경 시 동기화
   useEffect(() => {
     setInputStatus(status);
   }, [status]);
 
+  // validation 로직 (선택적)
   useEffect(() => {
     if (validate && inputValue) {
       const validationResult = validate(inputValue);
@@ -94,6 +95,7 @@ const Input = forwardRef<HTMLInputElement, InputProps>((props, ref) => {
     setShowPassword((prev) => !prev);
   };
 
+  // padding 스타일 계산
   const dynamicPaddingStyles = css`
     ${leftIcon && 'padding-left: 36px;'}
     ${(rightIcon || (showClearButton && inputValue)) && 'padding-right: 36px;'}

--- a/src/components/common/TextField.tsx
+++ b/src/components/common/TextField.tsx
@@ -1,0 +1,158 @@
+import React, { forwardRef } from 'react';
+
+import { css, SerializedStyles } from '@emotion/react';
+
+import Input, { InputProps } from '@/components/common/Input';
+import theme from '@/styles/theme';
+
+export interface TextFieldProps extends InputProps {
+  label?: string;
+  helperText?: string;
+  errorMessage?: string;
+  required?: boolean;
+  labelStyle?: SerializedStyles;
+  containerStyle?: SerializedStyles;
+  labelPosition?: 'top' | 'left'; // 레이아웃 방향
+  labelWidth?: number | string; // left일 때 label 너비
+}
+
+/**
+ * TextField - 완전한 Form Field 컴포넌트
+ * - Input 컴포넌트를 래핑
+ * - label, helper text, error message 포함
+ * - 세로/가로 레이아웃 지원
+ */
+const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
+  (
+    {
+      label,
+      helperText,
+      errorMessage,
+      required = false,
+      labelStyle,
+      containerStyle,
+      labelPosition = 'top',
+      labelWidth = 109,
+      ...inputProps
+    },
+    ref
+  ) => {
+    const hasError = Boolean(errorMessage);
+    const hasSuccess = Boolean(helperText && !hasError);
+    // status prop이 전달되면 그것을 사용, 없으면 자동 결정
+    const computedStatus = inputProps.status
+      ? inputProps.status
+      : hasError
+        ? 'error'
+        : hasSuccess
+          ? 'success'
+          : 'default';
+    const isHorizontal = labelPosition === 'left';
+
+    const inputWrapperStyles = isHorizontal ? inputWrapperHorizontalStyles : undefined;
+    const containerStyles = isHorizontal
+      ? [fieldContainerHorizontalStyles, containerStyle]
+      : [fieldContainerStyles, containerStyle];
+
+    return (
+      <div css={containerStyles}>
+        {label && (
+          <label
+            htmlFor={inputProps.id}
+            css={[
+              isHorizontal ? labelHorizontalStyles : labelStyles,
+              labelStyle,
+              isHorizontal &&
+                css`
+                  width: ${typeof labelWidth === 'number' ? `${labelWidth}px` : labelWidth};
+                `,
+            ]}
+          >
+            {label}
+            {required && <span css={requiredMarkerStyles}>*</span>}
+          </label>
+        )}
+
+        <div css={inputWrapperStyles}>
+          <Input {...inputProps} ref={ref} status={computedStatus} />
+
+          {(errorMessage || helperText) && (
+            <p
+              css={[
+                messageStyles,
+                hasError && errorMessageStyles,
+                helperText && !hasError && successMessageStyles,
+              ]}
+            >
+              {errorMessage || helperText}
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+);
+
+TextField.displayName = 'TextField';
+
+const fieldContainerStyles = css`
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
+`;
+
+const fieldContainerHorizontalStyles = css`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  width: 100%;
+`;
+
+const inputWrapperHorizontalStyles = css`
+  position: relative;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+`;
+
+const labelStyles = css`
+  font-size: ${theme.typography.fontSizes.body};
+  font-weight: ${theme.typography.fontWeight.medium};
+  color: ${theme.colors.gray[900]};
+  line-height: ${theme.typography.lineHeights.lg};
+`;
+
+const labelHorizontalStyles = css`
+  font-size: ${theme.typography.fontSizes.caption};
+  font-weight: ${theme.typography.fontWeight.regular};
+  color: ${theme.colors.gray[900]};
+  line-height: ${theme.typography.lineHeights.lg};
+  text-align: left;
+`;
+
+const requiredMarkerStyles = css`
+  color: ${theme.colors.main.alert};
+  margin-left: 4px;
+`;
+
+const messageStyles = css`
+  position: absolute;
+  left: 0;
+  bottom: -20px;
+  font-size: ${theme.typography.fontSizes.caption};
+  line-height: ${theme.typography.lineHeights.sm};
+  color: ${theme.colors.main.alert};
+  margin: 0;
+  text-indent: 5px;
+`;
+
+const errorMessageStyles = css`
+  color: ${theme.colors.main.alert};
+`;
+
+const successMessageStyles = css`
+  color: ${theme.colors.main.primary};
+`;
+
+export default TextField;

--- a/src/components/common/TextField.tsx
+++ b/src/components/common/TextField.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from 'react';
+import { forwardRef } from 'react';
 
 import { css, SerializedStyles } from '@emotion/react';
 
@@ -12,16 +12,10 @@ export interface TextFieldProps extends InputProps {
   required?: boolean;
   labelStyle?: SerializedStyles;
   containerStyle?: SerializedStyles;
-  labelPosition?: 'top' | 'left'; // 레이아웃 방향
-  labelWidth?: number | string; // left일 때 label 너비
+  labelPosition?: 'top' | 'left';
+  labelWidth?: number | string;
 }
 
-/**
- * TextField - 완전한 Form Field 컴포넌트
- * - Input 컴포넌트를 래핑
- * - label, helper text, error message 포함
- * - 세로/가로 레이아웃 지원
- */
 const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (
     {
@@ -39,7 +33,6 @@ const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   ) => {
     const hasError = Boolean(errorMessage);
     const hasSuccess = Boolean(helperText && !hasError);
-    // status prop이 전달되면 그것을 사용, 없으면 자동 결정
     const computedStatus = inputProps.status
       ? inputProps.status
       : hasError

--- a/src/components/page/mypage/ProfileInput.tsx
+++ b/src/components/page/mypage/ProfileInput.tsx
@@ -1,8 +1,8 @@
-import { InputHTMLAttributes, useEffect, useState } from 'react';
+import { forwardRef, InputHTMLAttributes } from 'react';
 
-import { css, SerializedStyles } from '@emotion/react';
+import { SerializedStyles } from '@emotion/react';
 
-import theme from '@/styles/theme';
+import BaseInput from '@/components/common/BaseInput';
 
 export type InputStatus = 'default' | 'error' | 'success';
 
@@ -14,89 +14,25 @@ interface ProfileInputProps extends InputHTMLAttributes<HTMLInputElement> {
   status?: InputStatus;
 }
 
-const ProfileInput: React.FC<ProfileInputProps> = ({
-  onChange,
-  value,
-  isDisabled = false,
-  customStyle,
-  status = 'default',
-  ...inputProps
-}) => {
-  const [inputStatus, setInputStatus] = useState<InputStatus>(status);
-
-  useEffect(() => {
-    setInputStatus(status);
-  }, [status]);
-
-  const currentInputStyles = [
-    baseInputStyles,
-    customStyle,
-    inputSizeStyles,
-    inputStatusStyles[inputStatus],
-  ];
-  return (
-    <input
+const ProfileInput = forwardRef<HTMLInputElement, ProfileInputProps>(
+  (
+    { onChange, value, isDisabled = false, customStyle, status = 'default', ...inputProps },
+    ref
+  ) => (
+    <BaseInput
       {...inputProps}
+      ref={ref}
       type='text'
       value={value}
       disabled={isDisabled}
-      css={currentInputStyles}
+      inputSize='md'
+      status={status}
       onChange={onChange}
+      customStyle={customStyle}
     />
-  );
-};
+  )
+);
 
-const baseInputStyles = css`
-  display: block;
-  width: 100%;
-  border: 1px solid ${theme.colors.gray[300]};
-  background-color: ${theme.colors.main.white};
-  outline: none;
-  transition: all 0.2s ease;
-  font-family: 'Pretendard', sans-serif;
-  line-height: 150%;
-
-  &::placeholder {
-    color: ${theme.colors.gray[700] + '4a'};
-    font-weight: ${theme.typography.fontWeight.regular};
-  }
-
-  &:hover:not(:disabled) {
-    border-color: ${theme.colors.main.primary};
-  }
-
-  &:focus:not(:disabled) {
-    border-color: ${theme.colors.main.primary};
-  }
-
-  &:disabled {
-    background-color: ${theme.colors.gray[100]};
-    cursor: not-allowed;
-  }
-`;
-
-const inputSizeStyles = `
-    height: ${theme.input.height.md};
-    padding: ${theme.input.padding.md};
-    font-size: ${theme.input.fontSize.md};
-`;
-
-const inputStatusStyles = {
-  default: css``,
-  error: css`
-    border-color: ${theme.colors.main.alert};
-
-    &:hover:not(:disabled) {
-      border-color: ${theme.colors.main.alert};
-    }
-
-    &:focus:not(:disabled) {
-      border-color: ${theme.colors.main.alert};
-    }
-  `,
-  success: css`
-    border-color: ${theme.colors.gray[400]};
-  `,
-};
+ProfileInput.displayName = 'ProfileInput';
 
 export default ProfileInput;

--- a/src/components/page/signup/SignUpForm.tsx
+++ b/src/components/page/signup/SignUpForm.tsx
@@ -197,7 +197,7 @@ const SignUpForm = ({ formData, setFormData }: SignUpFormProps) => {
         <label htmlFor='auth_code' css={labelStyle}>
           인증번호
         </label>
-        <div>
+        <div css={authCodeStyle}>
           <form css={formStyle} onSubmit={handleCodeVerification}>
             <VerificationInput
               id='auth_code'
@@ -379,12 +379,19 @@ const labelStyle = css`
   line-height: ${theme.typography.lineHeights.lg};
 `;
 
+const authCodeStyle = css`
+  position: relative;
+`;
+
 const messageStyle = css`
-  margin-top: 16px;
-  text-align: center;
-  color: ${theme.colors.main.alert};
+  position: absolute;
+  left: 0;
+  bottom: -20px;
   font-size: ${theme.typography.fontSizes.caption};
   line-height: ${theme.typography.lineHeights.sm};
+  color: ${theme.colors.main.alert};
+  margin: 0;
+  text-indent: 5px;
 `;
 const successMessageStyle = css`
   color: ${theme.colors.main.primary};

--- a/src/components/page/signup/SignUpForm.tsx
+++ b/src/components/page/signup/SignUpForm.tsx
@@ -3,7 +3,7 @@ import { useState } from 'react';
 import { css } from '@emotion/react';
 
 import Button from '@/components/common/Button';
-import Input from '@/components/common/Input';
+import TextField from '@/components/common/TextField';
 import VerificationInput from '@/components/page/signup/VerificationInput';
 import { useNicknameValidation } from '@/hooks/mutations/useNicknameValidation';
 import { UseSignupEmailVerification } from '@/hooks/mutations/useSignupEmailVerification';
@@ -169,40 +169,35 @@ const SignUpForm = ({ formData, setFormData }: SignUpFormProps) => {
   return (
     <div>
       <div css={inputGroupStyle}>
-        <label htmlFor='email' css={labelStyle}>
-          이메일
-        </label>
-        <div css={emailVerifyContainer}>
-          <div css={divGroupStyle}>
-            <Input
-              id='email'
-              type='text'
-              inputSize='md'
-              required
-              name='email'
-              placeholder='1234@naver.com'
-              value={formData.email}
-              onChange={handleEmailChange}
-              status={emailErrorMessage ? 'error' : 'default'}
-            />
-            {emailErrorMessage && <p css={messageStyle}>{emailErrorMessage}</p>}
-          </div>
-          <Button
-            type='button'
-            variant='primary'
-            size='sm'
-            width={100}
-            onClick={handleEmailVerification} // 인증요청
-          >
-            인증요청
-          </Button>
-        </div>
+        <TextField
+          id='email'
+          name='email'
+          type='text'
+          inputSize='md'
+          label='이메일'
+          labelPosition='left'
+          labelWidth={109}
+          required
+          placeholder='1234@naver.com'
+          value={formData.email}
+          onChange={handleEmailChange}
+          errorMessage={emailErrorMessage}
+        />
+        <Button
+          type='button'
+          variant='primary'
+          size='sm'
+          width={100}
+          onClick={handleEmailVerification} // 인증요청
+        >
+          인증요청
+        </Button>
       </div>
       <div css={inputGroupStyle}>
         <label htmlFor='auth_code' css={labelStyle}>
           인증번호
         </label>
-        <div css={divGroupStyle}>
+        <div>
           <form css={formStyle} onSubmit={handleCodeVerification}>
             <VerificationInput
               id='auth_code'
@@ -236,106 +231,76 @@ const SignUpForm = ({ formData, setFormData }: SignUpFormProps) => {
 
       {/* 비밀번호 입력 폼 */}
       <div css={inputGroupStyle}>
-        <label htmlFor='password' css={labelStyle}>
-          비밀번호
-        </label>
-        <div css={divGroupStyle}>
-          <Input
-            id='password'
-            name='password'
-            type='password'
-            inputSize='md'
-            placeholder='영문 숫자를 포함한 8자 이상'
-            value={formData.password}
-            onChange={handleInputChange}
-            status={
-              validationMessages.password
-                ? validationMessages.password.includes('사용 가능')
-                  ? 'success'
-                  : 'error'
-                : 'default'
-            }
-          />
-          {validationMessages.password && (
-            <p
-              css={[
-                messageStyle,
-                validationMessages.password.includes('사용 가능') && successMessageStyle,
-              ]}
-            >
-              {validationMessages.password}
-            </p>
-          )}
-        </div>
+        <TextField
+          id='password'
+          name='password'
+          type='password'
+          inputSize='md'
+          label='비밀번호'
+          labelPosition='left'
+          labelWidth={109}
+          placeholder='영문 숫자를 포함한 8자 이상'
+          value={formData.password}
+          onChange={handleInputChange}
+          helperText={
+            validationMessages.password?.includes('사용 가능')
+              ? validationMessages.password
+              : undefined
+          }
+          errorMessage={
+            validationMessages.password && !validationMessages.password.includes('사용 가능')
+              ? validationMessages.password
+              : ''
+          }
+        />
       </div>
 
       {/* 비밀번호 확인 입력 폼 */}
       <div css={inputGroupStyle}>
-        <label htmlFor='confirmPassword' css={labelStyle}>
-          비밀번호 확인
-        </label>
-        <div css={divGroupStyle}>
-          <Input
-            id='confirmPassword'
-            name='confirmPassword'
-            type='password'
-            inputSize='md'
-            placeholder='비밀번호를 한번 더 입력해주세요.'
-            value={formData.confirmPassword}
-            onChange={handleInputChange}
-            status={
-              validationMessages.confirmPassword
-                ? validationMessages.confirmPassword.includes('일치합니다')
-                  ? 'success'
-                  : 'error'
-                : 'default'
-            }
-          />
-          {validationMessages.confirmPassword && (
-            <p
-              css={[
-                messageStyle,
-                validationMessages.confirmPassword.includes('일치합니다') && successMessageStyle,
-              ]}
-            >
-              {validationMessages.confirmPassword}
-            </p>
-          )}
-        </div>
+        <TextField
+          id='confirmPassword'
+          name='confirmPassword'
+          type='password'
+          inputSize='md'
+          label='비밀번호 확인'
+          labelPosition='left'
+          labelWidth={109}
+          placeholder='비밀번호를 한번 더 입력해주세요.'
+          value={formData.confirmPassword}
+          onChange={handleInputChange}
+          helperText={
+            validationMessages.confirmPassword?.includes('일치합니다')
+              ? validationMessages.confirmPassword
+              : undefined
+          }
+          errorMessage={
+            validationMessages.confirmPassword &&
+            !validationMessages.confirmPassword.includes('일치합니다')
+              ? validationMessages.confirmPassword
+              : ''
+          }
+        />
       </div>
 
       {/* 닉네임 입력 폼 */}
       <div css={inputGroupStyle}>
-        <label htmlFor='nickname' css={labelStyle}>
-          닉네임
-        </label>
-        <div css={divGroupStyle}>
-          <Input
-            id='nickname'
-            name='nickname'
-            inputSize='md'
-            placeholder='사용할 닉네임을 입력해주세요.'
-            value={formData.nickname}
-            onChange={handleInputChange}
-            status={
-              nicknameMessage
-                ? nicknameMessage.includes('사용 가능한 닉네임')
-                  ? 'success'
-                  : 'error'
-                : 'default'
-            }
-          />
-          {nicknameMessage && (
-            <p
-              css={[
-                messageStyle,
-                nicknameMessage.includes('사용 가능한 닉네임') && successMessageStyle,
-              ]}
-            >
-              {nicknameMessage}
-            </p>
-          )}
-        </div>
+        <TextField
+          id='nickname'
+          name='nickname'
+          inputSize='md'
+          label='닉네임'
+          labelPosition='left'
+          labelWidth={109}
+          placeholder='사용할 닉네임을 입력해주세요.'
+          value={formData.nickname}
+          onChange={handleInputChange}
+          helperText={nicknameMessage?.includes('사용 가능한 닉네임') ? nicknameMessage : undefined}
+          errorMessage={
+            nicknameMessage && !nicknameMessage.includes('사용 가능한 닉네임')
+              ? nicknameMessage
+              : ''
+          }
+        />
         <Button
           variant='primary'
           size='sm'
@@ -349,36 +314,27 @@ const SignUpForm = ({ formData, setFormData }: SignUpFormProps) => {
 
       {/* 전화번호 입력 폼 */}
       <div css={inputGroupStyle}>
-        <label htmlFor='phoneNumber' css={labelStyle}>
-          휴대폰번호
-        </label>
-        <div css={divGroupStyle}>
-          <Input
-            id='phoneNumber'
-            name='phoneNumber'
-            inputSize='md'
-            placeholder='01012345678'
-            value={formData.phoneNumber}
-            onChange={handleInputChange}
-            status={
-              validationMessages.phoneNumber
-                ? validationMessages.phoneNumber.includes('사용 가능')
-                  ? 'success'
-                  : 'error'
-                : 'default'
-            }
-          />
-          {validationMessages.phoneNumber && (
-            <p
-              css={[
-                messageStyle,
-                validationMessages.phoneNumber.includes('사용 가능') && successMessageStyle,
-              ]}
-            >
-              {validationMessages.phoneNumber}
-            </p>
-          )}
-        </div>
+        <TextField
+          id='phoneNumber'
+          name='phoneNumber'
+          inputSize='md'
+          label='휴대폰번호'
+          labelPosition='left'
+          labelWidth={109}
+          placeholder='01012345678'
+          value={formData.phoneNumber}
+          onChange={handleInputChange}
+          helperText={
+            validationMessages.phoneNumber?.includes('사용 가능')
+              ? validationMessages.phoneNumber
+              : undefined
+          }
+          errorMessage={
+            validationMessages.phoneNumber && !validationMessages.phoneNumber.includes('사용 가능')
+              ? validationMessages.phoneNumber
+              : ''
+          }
+        />
       </div>
     </div>
   );
@@ -396,14 +352,10 @@ const inputGroupStyle = css`
   }
   button {
     margin-left: 12px;
+    flex-shrink: 0;
   }
 `;
 
-const emailVerifyContainer = css`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
 const formStyle = css`
   display: flex;
   justify-content: center;
@@ -426,17 +378,7 @@ const labelStyle = css`
   font-weight: ${theme.typography.fontWeight.regular};
   line-height: ${theme.typography.lineHeights.lg};
 `;
-const divGroupStyle = css`
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  p {
-    position: absolute;
-    left: 0;
-    text-indent: 5px;
-    bottom: -20px;
-  }
-`;
+
 const messageStyle = css`
   margin-top: 16px;
   text-align: center;

--- a/src/pages/auth/SignInPage.tsx
+++ b/src/pages/auth/SignInPage.tsx
@@ -4,7 +4,7 @@ import { css } from '@emotion/react';
 import { Link, useNavigate } from 'react-router-dom';
 
 import Button from '@/components/common/Button';
-import Input from '@/components/common/Input';
+import TextField from '@/components/common/TextField';
 import Toast from '@/components/common/Toast';
 import { AUTH_TEXT } from '@/constants/auth';
 import { ROUTES } from '@/constants/routes';
@@ -96,35 +96,35 @@ const SignInPage: React.FC = () => {
     <div css={containerStyle}>
       <h3 css={pageHeadingStyle}>{AUTH_TEXT.title}</h3>
       <form css={formStyle} onSubmit={handleSubmit}>
-        <div css={divStyle}>
-          <Input
-            ref={emailInputRef}
-            type='text'
-            inputSize='lg'
-            leftIcon='mail'
-            placeholder={AUTH_TEXT.input.email.placeholder}
-            showClearButton
-            value={email}
-            onChange={handleEmailChange}
-            status={errorField === 'email' ? 'error' : 'default'}
-          />
-        </div>
-        <div>
-          <Input
-            ref={passwordInputRef}
-            type='password'
-            inputSize='lg'
-            leftIcon='key'
-            rightIcon='eye'
-            placeholder={AUTH_TEXT.input.password.placeholder}
-            value={password}
-            onChange={handlePasswordChange}
-            status={errorField === 'password' ? 'error' : 'default'}
-          />
-          <Button type='submit' width={400} css={buttonStyle} disabled={!email || !password}>
-            {AUTH_TEXT.button.submit}
-          </Button>
-        </div>
+        <TextField
+          ref={emailInputRef}
+          type='text'
+          inputSize='lg'
+          leftIcon='mail'
+          placeholder={AUTH_TEXT.input.email.placeholder}
+          showClearButton
+          value={email}
+          onChange={handleEmailChange}
+          status={errorField === 'email' ? 'error' : 'default'}
+          containerStyle={fieldStyle}
+        />
+
+        <TextField
+          ref={passwordInputRef}
+          type='password'
+          inputSize='lg'
+          leftIcon='key'
+          rightIcon='eye'
+          placeholder={AUTH_TEXT.input.password.placeholder}
+          value={password}
+          onChange={handlePasswordChange}
+          status={errorField === 'password' ? 'error' : 'default'}
+          containerStyle={fieldStyle}
+        />
+
+        <Button type='submit' width={400} css={buttonStyle} disabled={!email || !password}>
+          {AUTH_TEXT.button.submit}
+        </Button>
       </form>
       {errorMessage && <p css={messageStyle}>{errorMessage}</p>}
       <ul css={signinLinkStyle}>
@@ -158,18 +158,20 @@ const pageHeadingStyle = css`
   margin-bottom: 32px;
 `;
 const formStyle = css`
+  display: flex;
   flex-direction: column;
+  gap: 12px;
 
   input {
     width: 400px;
     text-indent: 10px;
   }
 `;
-const divStyle = css`
-  margin-bottom: 12px;
+const fieldStyle = css`
+  width: 400px;
 `;
 const buttonStyle = css`
-  margin-top: 24px;
+  margin-top: 12px;
 `;
 const signinLinkStyle = css`
   display: flex;

--- a/src/pages/auth/signup/SignUpPage.tsx
+++ b/src/pages/auth/signup/SignUpPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import { css } from '@emotion/react';
 import { useLocation, useNavigate } from 'react-router-dom';
@@ -8,6 +8,7 @@ import SignUpForm from '@/components/page/signup/SignUpForm';
 import TermsContainer from '@/components/terms/TermsContainer';
 import { ROUTES } from '@/constants/routes';
 import { useSignupMutation } from '@/hooks/useSignupMutation';
+import { useSignupStore } from '@/stores/signupStore';
 import theme from '@/styles/theme';
 import { HomeRouteState } from '@/types/route';
 import { TermsState } from '@/types/signup';
@@ -24,6 +25,7 @@ const SignUpPage: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { userRole } = (location.state as HomeRouteState) || {};
+  const { actions } = useSignupStore();
 
   // 폼 데이터 상태 관리
   const [formData, setFormData] = useState<FormData>({
@@ -42,6 +44,10 @@ const SignUpPage: React.FC = () => {
     marketingOptional: false,
     promotionOptional: false,
   });
+
+  useEffect(() => {
+    actions.resetNicknameState();
+  }, [actions]);
 
   // 회원가입 mutation
   const signupMutation = useSignupMutation({

--- a/src/pages/test-page/InputTestPage.tsx
+++ b/src/pages/test-page/InputTestPage.tsx
@@ -153,20 +153,6 @@ const InputTestPage = () => {
                 `}
               />
             </div>
-            <div>
-              <h3>Search Input with Clear Button</h3>
-              <Input
-                leftIcon='search'
-                placeholder='Search...'
-                value={searchValue}
-                onChange={(e) => setSearchValue(e.target.value)}
-                showClearButton
-                customStyle={css`
-                  width: 300px;
-                  text-indent: 10px;
-                `}
-              />
-            </div>
           </div>
         </section>
 

--- a/src/pages/test-page/InputTestPage.tsx
+++ b/src/pages/test-page/InputTestPage.tsx
@@ -7,7 +7,6 @@ import Input from '@/components/common/Input';
 const InputTestPage = () => {
   const [emailValue, setEmailValue] = useState('');
   const [passwordValue, setPasswordValue] = useState('');
-  const [searchValue, setSearchValue] = useState('');
 
   // 비밀번호 유효성 검사
   const validatePassword = (value: string) => ({


### PR DESCRIPTION
# 🚀 풀 리퀘스트 제안

<!-- closes #is-->

## 📋 작업 내용

### 1. Input 컴포넌트 반박자 버그 수정
- Input 컴포넌트 내부 `useState` 제거하여 완전한 controlled component로 변경
- 부모 컴포넌트의 value prop을 직접 사용하도록 수정
- 타이핑 시 값이 반박자 늦게 업데이트되던 문제 해결

### 2. Input 컴포넌트에서 search 아이콘 제거
- SearchInput 컴포넌트가 별도로 존재하므로 Input에서 search 아이콘 제거
- `FiSearch` import 제거 및 `leftIcon` 타입에서 'search' 제거
- 관련 Storybook stories 업데이트 (Input.stories, TextField.stories, InputTestPage)

### 3. SignInPage 에러 메시지 표시 방식 개선
- TextField 컴포넌트에 `errorMessage` 대신 `status` prop 사용
- 에러 메시지를 각 input 아래가 아닌 form 중앙에 집중 표시
- 더 나은 UX 제공 (input은 border 색상만 변경, 메시지는 중앙 표시)

### 4. SignUpForm 전체 필드 TextField로 통합
- 이메일 필드를 TextField로 변경 (가로 레이아웃 적용)
- 닉네임 필드를 TextField로 변경 (가로 레이아웃 적용)
- 모든 입력 필드가 TextField로 통일되어 일관성 향상
- 사용하지 않는 CSS 스타일 제거 (코드 간소화)

### 5. SignUpPage 닉네임 상태 초기화 버그 수정
- useEffect로 컴포넌트 마운트 시 `resetNicknameState()` 호출
- 이전 페이지 방문 시 저장된 닉네임 에러 메시지가 남아있던 문제 해결
- 페이지 진입 시 항상 깨끗한 상태로 시작

## 🔧 변경 사항

- [ ] 📃 README.md
- [ ] 📦 package.json
- [ ] 🔥 파일 삭제
- [ ] 🧹 그 외 ex) .gitignore 등

### 주요 변경 파일
- `src/components/common/Input.tsx` - search 아이콘 제거, controlled component 변경
- `src/components/common/TextField.tsx` - status prop 지원 추가
- `src/pages/auth/SignInPage.tsx` - 전체 필드 TextField 적용
- `src/components/page/signup/SignUpForm.tsx` - 전체 필드 TextField 적용
- `src/pages/auth/signup/SignUpPage.tsx` - 닉네임 상태 초기화 추가


## 📸 스크린샷 (선택 사항)
### 문제
- Input 컴포넌트 내부 상태와 외부 상태가 분리되어 타이핑 시 값이 반박자 늦게 반영됨

### 해결
- controlled component 패턴 적용으로 즉시 반영되도록 수정

### 화면
<img width="1327" height="843" alt="스크린샷 2025-11-25 오후 5 32 10" src="https://github.com/user-attachments/assets/36529d50-a813-4dc4-ae4a-f89348b66cb3" />
<img width="1026" height="819" alt="스크린샷 2025-11-25 오후 5 33 10" src="https://github.com/user-attachments/assets/5cea0473-4ae8-4c3c-9d17-b9a8aeb1c70a" />

## 📄 기타
- 인증번호 입력 필드는 타이머 기능이 있는 특수 컴포넌트(VerificationInput)이므로 현재 구조 유지
- PasswordChange 컴포넌트는 특수한 2열 레이아웃이므로 Input 유지
